### PR TITLE
Update ci.yml - debian instead of ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [ "main" ]
 
+
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
"runs-on" was changed from 'ubuntu-latest' to 'debian-latest'  -------
docker uses a debian build to start from, thus better to keep the linux versions used consistent